### PR TITLE
Add AnacondaProject spec for anaconda-project.yml

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -34,6 +34,7 @@ User Classes
     content.environment.PythonRequirements
     content.metadata.Licensed
     proj.ai.AIEnabled
+    proj.anaconda_project.AnacondaProject
     proj.briefcase.Briefcase
     proj.cicd.GitHubActions
     proj.cicd.GitLabCI
@@ -115,6 +116,7 @@ User Classes
 .. autoclass:: projspec.content.environment.PythonRequirements
 .. autoclass:: projspec.content.metadata.Licensed
 .. autoclass:: projspec.proj.ai.AIEnabled
+.. autoclass:: projspec.proj.anaconda_project.AnacondaProject
 .. autoclass:: projspec.proj.briefcase.Briefcase
 .. autoclass:: projspec.proj.cicd.GitHubActions
 .. autoclass:: projspec.proj.cicd.GitLabCI

--- a/src/projspec/proj/__init__.py
+++ b/src/projspec/proj/__init__.py
@@ -3,6 +3,7 @@
 from projspec.proj.base import ParseFailed, Project, ProjectSpec, ProjectExtra
 
 from projspec.proj.ai import AIEnabled
+from projspec.proj.anaconda_project import AnacondaProject
 from projspec.proj.backstage import BackstageCatalog
 from projspec.proj.briefcase import Briefcase
 from projspec.proj.cicd import (
@@ -77,6 +78,7 @@ __all__ = [
     "Taskfile",
     "Tox",
     # Conda
+    "AnacondaProject",
     "CondaRecipe",
     "CondaProject",
     "CondaWorkspace",

--- a/src/projspec/proj/anaconda_project.py
+++ b/src/projspec/proj/anaconda_project.py
@@ -1,19 +1,11 @@
-"""Anaconda Project (``anaconda-project.yml``) adapter.
-
-The legacy Anaconda-ecosystem project format used by Anaconda Enterprise /
-Anaconda Workbench. Recognised by the ``anaconda-project.yml`` (or
-``anaconda-project.yaml``) manifest at the project root; the sibling
-``anaconda-project-lock.yml`` holds per-env-spec, per-platform locked
-package lists.
-
-Spec reference:
-https://anaconda-project.readthedocs.io/en/latest/user-guide/reference.html
-"""
+"""Adapter for the legacy ``anaconda-project.yml`` manifest format."""
 
 import os
 
+import yaml
+
 from projspec.proj import ProjectSpec
-from projspec.utils import AttrDict, _yaml_no_jinja
+from projspec.utils import AttrDict
 
 
 _MANIFESTS = ("anaconda-project.yml", "anaconda-project.yaml")
@@ -21,7 +13,16 @@ _LOCKS = ("anaconda-project-lock.yml", "anaconda-project-lock.yaml")
 
 
 class AnacondaProject(ProjectSpec):
-    """Legacy Anaconda Project format (``anaconda-project.yml``)."""
+    """Legacy Anaconda Project format (``anaconda-project.yml``).
+
+    The project format used by Anaconda Enterprise / Anaconda Workbench and
+    the ``anaconda-project`` CLI. Recognised by the ``anaconda-project.yml``
+    (or ``anaconda-project.yaml``) manifest at the project root; the sibling
+    ``anaconda-project-lock.yml`` holds per-env-spec, per-platform locked
+    package lists.
+
+    Reference: https://anaconda-project.readthedocs.io/en/latest/user-guide/reference.html
+    """
 
     icon = "🅰"
     spec_doc = (
@@ -39,14 +40,14 @@ class AnacondaProject(ProjectSpec):
         from projspec.content.metadata import DescriptiveMetadata
 
         manifest_name = next(n for n in _MANIFESTS if n in self.proj.basenames)
-        with self.proj.get_file(manifest_name, text=False) as f:
-            meta = _yaml_no_jinja(f) or {}
+        with self.proj.get_file(manifest_name, text=True) as f:
+            meta = yaml.safe_load(f) or {}
 
         lock_name = next((n for n in _LOCKS if n in self.proj.basenames), None)
         lock_data = None
         if lock_name:
-            with self.proj.get_file(lock_name, text=False) as f:
-                lock_data = _yaml_no_jinja(f) or {}
+            with self.proj.get_file(lock_name, text=True) as f:
+                lock_data = yaml.safe_load(f) or {}
 
         top_channels = list(meta.get("channels", []) or [])
         top_conda, top_pip = _split_pip(meta.get("packages") or meta.get("dependencies") or [])

--- a/src/projspec/proj/anaconda_project.py
+++ b/src/projspec/proj/anaconda_project.py
@@ -50,7 +50,9 @@ class AnacondaProject(ProjectSpec):
                 lock_data = yaml.safe_load(f) or {}
 
         top_channels = list(meta.get("channels", []) or [])
-        top_conda, top_pip = _split_pip(meta.get("packages") or meta.get("dependencies") or [])
+        top_conda, top_pip = _split_pip(
+            meta.get("packages") or meta.get("dependencies") or []
+        )
         top_platforms = list(meta.get("platforms", []) or [])
 
         raw_env_specs = meta.get("env_specs") or {}
@@ -102,7 +104,9 @@ class AnacondaProject(ProjectSpec):
 
             if lock_data is not None:
                 locked_pkgs = _lock_packages_for(
-                    lock_data, env_name, spec_platforms=spec.get("platforms") or top_platforms
+                    lock_data,
+                    env_name,
+                    spec_platforms=spec.get("platforms") or top_platforms,
                 )
                 if locked_pkgs:
                     envs[f"{env_name}.lock"] = Environment(
@@ -138,7 +142,9 @@ class AnacondaProject(ProjectSpec):
             command_kinds=command_kinds,
             command_env_specs=command_env_specs,
             command_http=command_http,
-            lock_enabled=(lock_data or {}).get("locking_enabled") if lock_data else None,
+            lock_enabled=(lock_data or {}).get("locking_enabled")
+            if lock_data
+            else None,
         )
 
         conts = AttrDict(environment=envs, command=cmds)
@@ -359,12 +365,21 @@ def _variables_content(raw_vars, proj):
     return EnvironmentVariables(proj=proj, variables=out)
 
 
-def _collect_extras(meta: dict, *, command_kinds, command_env_specs,
-                    command_http, lock_enabled) -> dict:
+def _collect_extras(
+    meta: dict, *, command_kinds, command_env_specs, command_http, lock_enabled
+) -> dict:
     """Collect fields projspec does not yet model into a flat metadata dict."""
     extras: dict = {}
-    for key in ("name", "description", "icon", "categories",
-                "platforms", "downloads", "services", "skip_imports"):
+    for key in (
+        "name",
+        "description",
+        "icon",
+        "categories",
+        "platforms",
+        "downloads",
+        "services",
+        "skip_imports",
+    ):
         if key in meta and meta[key] not in (None, [], {}):
             extras[key] = meta[key]
     if command_kinds:

--- a/src/projspec/proj/anaconda_project.py
+++ b/src/projspec/proj/anaconda_project.py
@@ -1,0 +1,377 @@
+"""Anaconda Project (``anaconda-project.yml``) adapter.
+
+The legacy Anaconda-ecosystem project format used by Anaconda Enterprise /
+Anaconda Workbench. Recognised by the ``anaconda-project.yml`` (or
+``anaconda-project.yaml``) manifest at the project root; the sibling
+``anaconda-project-lock.yml`` holds per-env-spec, per-platform locked
+package lists.
+
+Spec reference:
+https://anaconda-project.readthedocs.io/en/latest/user-guide/reference.html
+"""
+
+import os
+
+from projspec.proj import ProjectSpec
+from projspec.utils import AttrDict, _yaml_no_jinja
+
+
+_MANIFESTS = ("anaconda-project.yml", "anaconda-project.yaml")
+_LOCKS = ("anaconda-project-lock.yml", "anaconda-project-lock.yaml")
+
+
+class AnacondaProject(ProjectSpec):
+    """Legacy Anaconda Project format (``anaconda-project.yml``)."""
+
+    icon = "🅰"
+    spec_doc = (
+        "https://anaconda-project.readthedocs.io/en/latest/user-guide/reference.html"
+    )
+
+    def match(self) -> bool:
+        return any(n in self.proj.basenames for n in _MANIFESTS)
+
+    def parse(self) -> None:
+        from projspec.artifact.process import Process
+        from projspec.artifact.python_env import CondaEnv, LockFile
+        from projspec.content.environment import Environment, Precision, Stack
+        from projspec.content.executable import Command
+        from projspec.content.metadata import DescriptiveMetadata
+
+        manifest_name = next(n for n in _MANIFESTS if n in self.proj.basenames)
+        with self.proj.get_file(manifest_name, text=False) as f:
+            meta = _yaml_no_jinja(f) or {}
+
+        lock_name = next((n for n in _LOCKS if n in self.proj.basenames), None)
+        lock_data = None
+        if lock_name:
+            with self.proj.get_file(lock_name, text=False) as f:
+                lock_data = _yaml_no_jinja(f) or {}
+
+        top_channels = list(meta.get("channels", []) or [])
+        top_conda, top_pip = _split_pip(meta.get("packages") or meta.get("dependencies") or [])
+        top_platforms = list(meta.get("platforms", []) or [])
+
+        raw_env_specs = meta.get("env_specs") or {}
+        if not raw_env_specs:
+            # anaconda-project implies a ``default`` env_spec when none is
+            # declared (see the reference guide: "creates an environment in
+            # envs/default by default").
+            raw_env_specs = {"default": {}}
+        resolved_specs = _resolve_inheritance(raw_env_specs)
+
+        envs = AttrDict()
+        runtimes = AttrDict()
+        locks = AttrDict()
+        cmds = AttrDict()
+        procs = AttrDict()
+
+        for env_name, spec in resolved_specs.items():
+            env_conda, env_pip = _split_pip(spec.get("packages") or [])
+            channels = _merge(top_channels, spec.get("channels") or [])
+            conda_packages = _merge(top_conda, env_conda)
+            pip_packages = _merge(top_pip, env_pip)
+
+            envs[env_name] = Environment(
+                proj=self.proj,
+                channels=channels,
+                packages=conda_packages,
+                stack=Stack.CONDA,
+                precision=Precision.SPEC,
+            )
+            if pip_packages:
+                envs[f"{env_name}.pip"] = Environment(
+                    proj=self.proj,
+                    channels=[],
+                    packages=pip_packages,
+                    stack=Stack.PIP,
+                    precision=Precision.SPEC,
+                )
+
+            runtimes[env_name] = CondaEnv(
+                proj=self.proj,
+                fn=f"{self.proj.url}/envs/{env_name}",
+                cmd=["anaconda-project", "prepare", "--env-spec", env_name],
+            )
+            locks[env_name] = LockFile(
+                proj=self.proj,
+                fn=f"{self.proj.url}/anaconda-project-lock.yml",
+                cmd=["anaconda-project", "lock", "--env-spec", env_name],
+            )
+
+            if lock_data is not None:
+                locked_pkgs = _lock_packages_for(
+                    lock_data, env_name, spec_platforms=spec.get("platforms") or top_platforms
+                )
+                if locked_pkgs:
+                    envs[f"{env_name}.lock"] = Environment(
+                        proj=self.proj,
+                        channels=[],
+                        packages=locked_pkgs,
+                        stack=Stack.CONDA,
+                        precision=Precision.LOCK,
+                    )
+
+        command_kinds = {}
+        command_env_specs = {}
+        command_http = {}
+        for cname, cspec in (meta.get("commands") or {}).items():
+            shell = _command_shell(cspec, command_kinds, cname)
+            if shell is None:
+                continue
+            cmds[cname] = Command(proj=self.proj, cmd=shell)
+            procs[cname] = Process(
+                proj=self.proj,
+                cmd=["anaconda-project", "run", cname],
+            )
+            if isinstance(cspec, dict):
+                if cspec.get("env_spec"):
+                    command_env_specs[cname] = cspec["env_spec"]
+                if cspec.get("supports_http_options"):
+                    command_http[cname] = True
+
+        var_content = _variables_content(meta.get("variables") or {}, self.proj)
+
+        extras = _collect_extras(
+            meta,
+            command_kinds=command_kinds,
+            command_env_specs=command_env_specs,
+            command_http=command_http,
+            lock_enabled=(lock_data or {}).get("locking_enabled") if lock_data else None,
+        )
+
+        conts = AttrDict(environment=envs, command=cmds)
+        if var_content is not None:
+            conts["environment_variables"] = var_content
+        if extras:
+            conts["descriptive_metadata"] = DescriptiveMetadata(
+                proj=self.proj, meta=extras
+            )
+
+        arts = AttrDict(conda_env=runtimes, lock_file=locks, process=procs)
+
+        self._contents = conts
+        self._artifacts = arts
+
+    @staticmethod
+    def _create(path: str) -> None:
+        name = os.path.basename(path.rstrip("/")) or "project"
+        with open(f"{path}/anaconda-project.yml", "wt") as f:
+            f.write(
+                f"""name: {name}
+description: ""
+
+packages:
+  - python
+
+platforms:
+  - linux-64
+  - osx-64
+  - osx-arm64
+  - win-64
+
+env_specs:
+  default: {{}}
+
+commands: {{}}
+
+variables: {{}}
+"""
+            )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _merge(base: list, extra: list) -> list:
+    """Append items from *extra* to *base* preserving order, no duplicates."""
+    out = list(base)
+    for item in extra:
+        if item not in out:
+            out.append(item)
+    return out
+
+
+def _split_pip(packages):
+    """Split an anaconda-project ``packages:`` list into (conda, pip) parts.
+
+    ``packages`` entries are strings; a dict with a single ``pip:`` key holds a
+    list of pip requirement specifiers.
+    """
+    conda, pip = [], []
+    for item in packages or []:
+        if isinstance(item, dict) and "pip" in item:
+            for p in item.get("pip") or []:
+                if p not in pip:
+                    pip.append(p)
+        elif isinstance(item, str):
+            if item not in conda:
+                conda.append(item)
+    return conda, pip
+
+
+def _resolve_inheritance(raw_specs: dict) -> dict:
+    """Flatten ``inherit_from`` chains, merging packages/channels/platforms additively.
+
+    Parents are resolved first; child overrides nothing, only extends. Cycles
+    are broken by treating already-visited specs as terminal.
+    """
+    resolved: dict[str, dict] = {}
+
+    def resolve(name: str, stack: tuple[str, ...]) -> dict:
+        if name in resolved:
+            return resolved[name]
+        if name in stack:
+            return dict(raw_specs.get(name) or {})
+        spec = dict(raw_specs.get(name) or {})
+        parents = spec.pop("inherit_from", None)
+        if parents is None:
+            resolved[name] = spec
+            return spec
+        if isinstance(parents, str):
+            parents = [parents]
+        merged_packages: list = []
+        merged_channels: list = []
+        merged_platforms: list = []
+        for p in parents:
+            if p not in raw_specs:
+                continue
+            r = resolve(p, stack + (name,))
+            merged_packages = _merge(merged_packages, r.get("packages") or [])
+            merged_channels = _merge(merged_channels, r.get("channels") or [])
+            merged_platforms = _merge(merged_platforms, r.get("platforms") or [])
+        out = dict(spec)
+        out["packages"] = _merge(merged_packages, spec.get("packages") or [])
+        out["channels"] = _merge(merged_channels, spec.get("channels") or [])
+        plat = _merge(merged_platforms, spec.get("platforms") or [])
+        if plat:
+            out["platforms"] = plat
+        resolved[name] = out
+        return out
+
+    for name in raw_specs:
+        resolve(name, ())
+    return resolved
+
+
+def _lock_packages_for(lock_data: dict, env_name: str, spec_platforms: list) -> list:
+    """Extract a flat, deduplicated list of locked package strings for *env_name*.
+
+    The ``anaconda-project-lock.yml`` layout is::
+
+        env_specs:
+          <env>:
+            locked: true
+            platforms: [linux-64, osx-64, ...]
+            packages:
+              all:   [...]       # every platform
+              unix:  [...]       # linux-* and osx-*
+              win-64: [...]      # platform-specific
+              linux-64: [...]
+              ...
+
+    We return ``all`` ∪ (``unix`` if any unix platform is in scope) ∪
+    per-platform entries for platforms declared by the env spec. Falling back
+    to every platform group present if the env doesn't declare platforms.
+    """
+    entry = (lock_data.get("env_specs") or {}).get(env_name) or {}
+    if not entry:
+        return []
+    if entry.get("locked") is False:
+        return []
+
+    buckets = entry.get("packages") or {}
+    platforms = list(entry.get("platforms") or spec_platforms or [])
+
+    want = {"all"}
+    if platforms:
+        want.update(platforms)
+        if any(p.startswith(("linux-", "osx-")) for p in platforms):
+            want.add("unix")
+    else:
+        want.update(buckets.keys())
+
+    out: list[str] = []
+    for group in buckets:
+        if group in want:
+            for pkg in buckets[group] or []:
+                if pkg not in out:
+                    out.append(pkg)
+    return out
+
+
+def _command_shell(cspec, command_kinds: dict, cname: str) -> str | None:
+    """Best-effort shell string for a command spec.
+
+    Follows the conventions used by ``anaconda-project export-pixi``:
+    notebook commands become ``jupyter notebook <path>`` and bokeh_app
+    commands become ``bokeh serve <path>``. The original kind + path is
+    recorded in *command_kinds* so no fidelity is lost.
+    """
+    if isinstance(cspec, str):
+        return cspec
+    if not isinstance(cspec, dict):
+        return None
+    for key in ("unix", "bash"):
+        if cspec.get(key):
+            return cspec[key]
+    if cspec.get("notebook"):
+        command_kinds.setdefault(cname, {})["notebook"] = cspec["notebook"]
+        return f"jupyter notebook {cspec['notebook']}"
+    if cspec.get("bokeh_app"):
+        command_kinds.setdefault(cname, {})["bokeh_app"] = cspec["bokeh_app"]
+        return f"bokeh serve {cspec['bokeh_app']}"
+    if cspec.get("windows"):
+        command_kinds.setdefault(cname, {})["windows_only"] = True
+        return cspec["windows"]
+    return None
+
+
+def _variables_content(raw_vars, proj):
+    """Reduce ``variables:`` (list or dict form) to ``EnvironmentVariables``.
+
+    The dict form's ``default`` becomes the value; prompting/encryption
+    metadata is discarded for now (see upstream issue).
+    """
+    from projspec.content.env_var import EnvironmentVariables
+
+    if not raw_vars:
+        return None
+    out: dict[str, str | None] = {}
+    if isinstance(raw_vars, list):
+        for name in raw_vars:
+            if isinstance(name, str):
+                out[name] = None
+    elif isinstance(raw_vars, dict):
+        for name, spec in raw_vars.items():
+            if isinstance(spec, dict):
+                default = spec.get("default")
+                out[name] = str(default) if default is not None else None
+            elif spec is None:
+                out[name] = None
+            else:
+                out[name] = str(spec)
+    if not out:
+        return None
+    return EnvironmentVariables(proj=proj, variables=out)
+
+
+def _collect_extras(meta: dict, *, command_kinds, command_env_specs,
+                    command_http, lock_enabled) -> dict:
+    """Collect fields projspec does not yet model into a flat metadata dict."""
+    extras: dict = {}
+    for key in ("name", "description", "icon", "categories",
+                "platforms", "downloads", "services", "skip_imports"):
+        if key in meta and meta[key] not in (None, [], {}):
+            extras[key] = meta[key]
+    if command_kinds:
+        extras["command_kinds"] = command_kinds
+    if command_env_specs:
+        extras["command_env_specs"] = command_env_specs
+    if command_http:
+        extras["command_supports_http_options"] = command_http
+    if lock_enabled is not None:
+        extras["locking_enabled"] = lock_enabled
+    return extras

--- a/tests/test_anaconda_project.py
+++ b/tests/test_anaconda_project.py
@@ -1,0 +1,384 @@
+"""Tests for the :class:`AnacondaProject` spec (legacy ``anaconda-project.yml``).
+
+Fixtures are hand-written but modelled on the real sample projects at
+https://github.com/anaconda/workbench-sample-projects and the examples in
+https://github.com/anaconda/anaconda-project/tree/master/examples .
+"""
+import os
+import textwrap
+
+import projspec
+from projspec.proj.anaconda_project import AnacondaProject
+
+
+def write_files(tmpdir, files: dict) -> str:
+    path = str(tmpdir)
+    for rel, content in files.items():
+        full = os.path.join(path, rel)
+        os.makedirs(os.path.dirname(full), exist_ok=True)
+        with open(full, "w") as f:
+            f.write(textwrap.dedent(content))
+    return path
+
+
+def make_proj(tmpdir, files: dict):
+    return projspec.Project(write_files(tmpdir, files))
+
+
+def raw_spec(cls, proj):
+    inst = cls.__new__(cls)
+    inst.proj = proj
+    inst._contents = None
+    inst._artifacts = None
+    return inst
+
+
+HELLO_ANACONDA = {
+    "anaconda-project.yml": """\
+        name: Hello Anaconda Enterprise
+        description: A simple hello-world anaconda-project app.
+        categories:
+          - Python
+
+        commands:
+          default:
+            unix: python ${PROJECT_DIR}/hello.py
+            windows: python %PROJECT_DIR%\\hello.py
+            supports_http_options: true
+          run:
+            unix: python ${PROJECT_DIR}/run.py
+
+        variables:
+          INTEGRATION_TEST_ANACONDA:
+            default: anaconda
+          INTEGRATION_TEST_VERSION:
+            default: test
+
+        packages:
+          - python=3.7
+          - ipykernel
+        platforms:
+          - linux-64
+
+        env_specs:
+          python_37: {}
+        """,
+}
+
+
+class TestMatch:
+    def test_match_positive(self, tmpdir):
+        proj = make_proj(tmpdir, HELLO_ANACONDA)
+        assert raw_spec(AnacondaProject, proj).match()
+
+    def test_match_yaml_extension(self, tmpdir):
+        files = {"anaconda-project.yaml": HELLO_ANACONDA["anaconda-project.yml"]}
+        proj = make_proj(tmpdir, files)
+        assert raw_spec(AnacondaProject, proj).match()
+
+    def test_match_negative(self, tmpdir):
+        proj = make_proj(tmpdir, {})
+        assert not raw_spec(AnacondaProject, proj).match()
+
+    def test_conda_project_yml_does_not_match(self, tmpdir):
+        """Sanity check: an unrelated conda-project manifest should not match."""
+        proj = make_proj(tmpdir, {"conda-project.yml": "name: x\n"})
+        assert not raw_spec(AnacondaProject, proj).match()
+
+
+class TestBasicParse:
+    def test_spec_registered(self, tmpdir):
+        proj = make_proj(tmpdir, HELLO_ANACONDA)
+        assert "anaconda_project" in proj.specs
+
+    def test_commands(self, tmpdir):
+        proj = make_proj(tmpdir, HELLO_ANACONDA)
+        cmds = proj.specs["anaconda_project"].contents["command"]
+        assert set(cmds) == {"default", "run"}
+        assert cmds["default"].cmd == "python ${PROJECT_DIR}/hello.py"
+        assert cmds["run"].cmd == "python ${PROJECT_DIR}/run.py"
+
+    def test_env_spec(self, tmpdir):
+        proj = make_proj(tmpdir, HELLO_ANACONDA)
+        envs = proj.specs["anaconda_project"].contents["environment"]
+        assert "python_37" in envs
+        env = envs["python_37"]
+        assert env.stack.name == "CONDA"
+        assert env.precision.name == "SPEC"
+        assert env.packages == ["python=3.7", "ipykernel"]
+
+    def test_variables(self, tmpdir):
+        proj = make_proj(tmpdir, HELLO_ANACONDA)
+        vars_content = proj.specs["anaconda_project"].contents["environment_variables"]
+        assert vars_content.variables == {
+            "INTEGRATION_TEST_ANACONDA": "anaconda",
+            "INTEGRATION_TEST_VERSION": "test",
+        }
+
+    def test_artifacts(self, tmpdir):
+        proj = make_proj(tmpdir, HELLO_ANACONDA)
+        arts = proj.specs["anaconda_project"].artifacts
+        assert "python_37" in arts["conda_env"]
+        assert "python_37" in arts["lock_file"]
+        assert set(arts["process"]) == {"default", "run"}
+
+    def test_extras_carry_unmodelled_fields(self, tmpdir):
+        proj = make_proj(tmpdir, HELLO_ANACONDA)
+        meta = proj.specs["anaconda_project"].contents["descriptive_metadata"].meta
+        assert meta["name"] == "Hello Anaconda Enterprise"
+        assert meta["categories"] == ["Python"]
+        assert meta["platforms"] == ["linux-64"]
+        assert meta["command_supports_http_options"] == {"default": True}
+
+
+class TestInheritance:
+    FILES = {
+        "anaconda-project.yml": """\
+            name: inh
+            channels: [defaults]
+            packages:
+              - python
+            platforms: [linux-64]
+            env_specs:
+              test_packages:
+                packages: [pytest, pytest-cov]
+              app_dependencies:
+                packages: [bokeh]
+              app_test_dependencies:
+                inherit_from: [test_packages, app_dependencies]
+                packages: [tornado]
+            commands:
+              test:
+                unix: python -m pytest myapp/tests
+                env_spec: app_test_dependencies
+            """,
+    }
+
+    def test_inherited_packages_flattened(self, tmpdir):
+        proj = make_proj(tmpdir, self.FILES)
+        envs = proj.specs["anaconda_project"].contents["environment"]
+        assert envs["app_test_dependencies"].packages == [
+            "python",
+            "pytest",
+            "pytest-cov",
+            "bokeh",
+            "tornado",
+        ]
+
+    def test_top_level_channels_propagate(self, tmpdir):
+        proj = make_proj(tmpdir, self.FILES)
+        envs = proj.specs["anaconda_project"].contents["environment"]
+        assert envs["test_packages"].channels == ["defaults"]
+
+    def test_command_env_spec_recorded(self, tmpdir):
+        proj = make_proj(tmpdir, self.FILES)
+        meta = proj.specs["anaconda_project"].contents["descriptive_metadata"].meta
+        assert meta["command_env_specs"] == {"test": "app_test_dependencies"}
+
+
+class TestPipDependencies:
+    FILES = {
+        "anaconda-project.yml": """\
+            name: pipproj
+            packages:
+              - python
+              - pip:
+                - requests>=2.28
+                - flask==3.0
+            platforms: [linux-64]
+            env_specs:
+              default: {}
+            """,
+    }
+
+    def test_pip_split_into_separate_environment(self, tmpdir):
+        proj = make_proj(tmpdir, self.FILES)
+        envs = proj.specs["anaconda_project"].contents["environment"]
+        assert envs["default"].packages == ["python"]
+        assert envs["default"].stack.name == "CONDA"
+        assert envs["default.pip"].packages == ["requests>=2.28", "flask==3.0"]
+        assert envs["default.pip"].stack.name == "PIP"
+
+
+class TestCommandKinds:
+    FILES = {
+        "anaconda-project.yml": """\
+            name: kinds
+            packages: [python]
+            platforms: [linux-64]
+            env_specs:
+              default: {}
+            commands:
+              notebook_cmd:
+                notebook: analysis.ipynb
+              bokeh_cmd:
+                bokeh_app: .
+              shell_cmd:
+                unix: echo hi
+              string_cmd: echo direct
+            """,
+    }
+
+    def test_notebook_translated_to_jupyter(self, tmpdir):
+        proj = make_proj(tmpdir, self.FILES)
+        cmds = proj.specs["anaconda_project"].contents["command"]
+        assert cmds["notebook_cmd"].cmd == "jupyter notebook analysis.ipynb"
+
+    def test_bokeh_app_translated(self, tmpdir):
+        proj = make_proj(tmpdir, self.FILES)
+        cmds = proj.specs["anaconda_project"].contents["command"]
+        assert cmds["bokeh_cmd"].cmd == "bokeh serve ."
+
+    def test_plain_unix_passthrough(self, tmpdir):
+        proj = make_proj(tmpdir, self.FILES)
+        cmds = proj.specs["anaconda_project"].contents["command"]
+        assert cmds["shell_cmd"].cmd == "echo hi"
+
+    def test_bare_string_command(self, tmpdir):
+        proj = make_proj(tmpdir, self.FILES)
+        cmds = proj.specs["anaconda_project"].contents["command"]
+        assert cmds["string_cmd"].cmd == "echo direct"
+
+    def test_original_kind_preserved_in_extras(self, tmpdir):
+        proj = make_proj(tmpdir, self.FILES)
+        meta = proj.specs["anaconda_project"].contents["descriptive_metadata"].meta
+        assert meta["command_kinds"] == {
+            "notebook_cmd": {"notebook": "analysis.ipynb"},
+            "bokeh_cmd": {"bokeh_app": "."},
+        }
+
+
+class TestLockFile:
+    MANIFEST = """\
+        name: Stocks Example
+        commands:
+          default:
+            bokeh_app: .
+        packages:
+          - bokeh=0.12
+          - pandas
+        env_specs:
+          default: {}
+        platforms:
+          - linux-64
+          - osx-64
+          - win-64
+        """
+    LOCK = """\
+        locking_enabled: true
+        env_specs:
+          default:
+            locked: true
+            platforms: [linux-64, osx-64, win-64]
+            packages:
+              all:
+                - bokeh=0.12.5=py27_0
+                - pandas=0.20.1=np112py27_0
+              unix:
+                - openssl=1.0.2k=2
+              win-64:
+                - vs2008_runtime=9.00.30729.5054=0
+        """
+
+    def test_lock_precision_environment_emitted(self, tmpdir):
+        proj = make_proj(
+            tmpdir,
+            {
+                "anaconda-project.yml": self.MANIFEST,
+                "anaconda-project-lock.yml": self.LOCK,
+            },
+        )
+        envs = proj.specs["anaconda_project"].contents["environment"]
+        assert "default.lock" in envs
+        locked = envs["default.lock"]
+        assert locked.precision.name == "LOCK"
+        assert "bokeh=0.12.5=py27_0" in locked.packages
+        assert "openssl=1.0.2k=2" in locked.packages
+        assert "vs2008_runtime=9.00.30729.5054=0" in locked.packages
+
+    def test_locking_enabled_carried_in_extras(self, tmpdir):
+        proj = make_proj(
+            tmpdir,
+            {
+                "anaconda-project.yml": self.MANIFEST,
+                "anaconda-project-lock.yml": self.LOCK,
+            },
+        )
+        meta = proj.specs["anaconda_project"].contents["descriptive_metadata"].meta
+        assert meta["locking_enabled"] is True
+
+    def test_no_lock_file_no_lock_environment(self, tmpdir):
+        proj = make_proj(tmpdir, {"anaconda-project.yml": self.MANIFEST})
+        envs = proj.specs["anaconda_project"].contents["environment"]
+        assert "default.lock" not in envs
+
+
+class TestDownloadsAndServices:
+    FILES = {
+        "anaconda-project.yml": """\
+            name: downloads
+            packages: [python]
+            platforms: [linux-64]
+            env_specs:
+              default: {}
+            downloads:
+              DATA:
+                url: https://example.com/data.parq
+                filename: data/x.parq
+            services:
+              REDIS_URL: redis
+            """,
+    }
+
+    def test_downloads_carried_verbatim(self, tmpdir):
+        proj = make_proj(tmpdir, self.FILES)
+        meta = proj.specs["anaconda_project"].contents["descriptive_metadata"].meta
+        assert meta["downloads"] == {
+            "DATA": {
+                "url": "https://example.com/data.parq",
+                "filename": "data/x.parq",
+            }
+        }
+
+    def test_services_carried_verbatim(self, tmpdir):
+        proj = make_proj(tmpdir, self.FILES)
+        meta = proj.specs["anaconda_project"].contents["descriptive_metadata"].meta
+        assert meta["services"] == {"REDIS_URL": "redis"}
+
+
+class TestVariableForms:
+    def test_list_form(self, tmpdir):
+        proj = make_proj(
+            tmpdir,
+            {
+                "anaconda-project.yml": """\
+                    name: v
+                    packages: [python]
+                    platforms: [linux-64]
+                    env_specs: {default: {}}
+                    variables:
+                      - FOO
+                      - BAR
+                    """,
+            },
+        )
+        vars_content = proj.specs["anaconda_project"].contents["environment_variables"]
+        assert vars_content.variables == {"FOO": None, "BAR": None}
+
+    def test_dict_form_without_default(self, tmpdir):
+        proj = make_proj(
+            tmpdir,
+            {
+                "anaconda-project.yml": """\
+                    name: v
+                    packages: [python]
+                    platforms: [linux-64]
+                    env_specs: {default: {}}
+                    variables:
+                      NEEDED:
+                        description: please set me
+                    """,
+            },
+        )
+        vars_content = proj.specs["anaconda_project"].contents["environment_variables"]
+        assert vars_content.variables == {"NEEDED": None}


### PR DESCRIPTION
## Summary

Adds a new `AnacondaProject` ProjectSpec for the legacy `anaconda-project.yml` format (as used by Anaconda Enterprise / Workbench and the `anaconda-project` CLI at https://github.com/anaconda/anaconda-project). Complements the existing `CondaProject` (conda-incubator's `conda-project.yml`), which is a different manifest despite the similar name.

### Motivation

`anaconda-project` itself is a legacy tool — it remains in use chiefly because Anaconda Enterprise / Workbench requires it, and that platform is on its way out. The immediate value of projspec being able to read the format is to support the *migration* of projects away from platforms that require it and onto more actively maintained ecosystems (pixi, uv, etc.).

Looking forward, projspec is a natural home for format-conversion tooling: once it can parse every format that matters, converting between them becomes a small layer on top of the existing `content` / `artifact` model. This PR only adds the reader; future work could add an emit/convert side. At that point projspec could serve as the essential middleware in a migration pipeline — a single library that understands the source format, normalises the project model, and emits a target format — rather than every migration tool reimplementing the same readers.

### What's modelled

| Manifest field | projspec model |
|---|---|
| `env_specs.<n>.packages` / `channels` (+ top-level propagation) | `Environment(stack=CONDA, precision=SPEC)` |
| `packages: [..., {pip: [...]}]` | additional `Environment(stack=PIP)` at `<env>.pip` |
| `env_specs.<n>.inherit_from` (string or list) | additive flatten of packages / channels / platforms |
| `anaconda-project-lock.yml` present | `Environment(precision=LOCK)`, merging `all` / `unix` / `<platform>` buckets |
| `commands.*.unix` / `bash` | `Command(cmd=str)` + `Process` artifact |
| `commands.*.notebook` | `Command(cmd="jupyter notebook <path>")` |
| `commands.*.bokeh_app` | `Command(cmd="bokeh serve <path>")` |
| `commands.*.windows` (only) | fallback `Command` |
| `variables` (list or dict with `default`) | `EnvironmentVariables` |
| implicit `default` env when `env_specs:` absent | `default` env spec materialised |

Artifacts (`CondaEnv` / `LockFile` / `Process`) are wired to `anaconda-project prepare|lock|run`.

### What's carried on `DescriptiveMetadata.meta`

Following the pattern used by `dataworkflows.py`, `infra.py`, `backstage.py`, etc., fields that don't yet have typed representations in projspec are preserved verbatim so nothing is lost:

* `name`, `description`, `icon`, `categories`
* `downloads`, `services`
* top-level `platforms`, `skip_imports`
* `command_kinds` — original `notebook` / `bokeh_app` paths before shell-string translation
* `command_env_specs` — per-command `env_spec` binding
* `command_supports_http_options`
* `locking_enabled`

### Out of scope (future upstream work)

* Prompted-variable metadata (`default` / `description` / `encrypted`)
* First-class `Download` / `Service` content types
* A `kind` field or subclass on `Command` (notebook, http-service)
* `platforms` as a first-class `Environment` field

## Test plan

* [x] 26 tests in `tests/test_anaconda_project.py` covering match, basic parse, inheritance, pip split, command kinds (notebook/bokeh_app/unix/string), lock file reading, downloads/services, variable forms — all inline fixtures, matching the style of `tests/test_new_specs.py`
* [x] `pytest tests/test_anaconda_project.py` — 26 passed
* [x] Full suite: `pytest tests/` — same 5 pre-existing "tool not installed" failures as on `main`, no new failures
* [x] Sanity-checked against 12 real manifests from [anaconda/workbench-sample-projects](https://github.com/anaconda/workbench-sample-projects) (attractors, databases, hadoop_spark, hello_anaconda_enterprise, holoviz, hvplot_notebook, image_classifier_flask, nyc_taxi, panel_gapminders, plot_notebook, streaming_ohlc_data, tensorboard_mnist) — all parse cleanly

Marked as draft pending any upstream shaping discussion.
